### PR TITLE
Fix for Instantaneous current field 

### DIFF
--- a/src/dsmr-be/fields-be.h
+++ b/src/dsmr-be/fields-be.h
@@ -280,11 +280,11 @@ DEFINE_FIELD(fuse_treshold_l2, uint16_t, ObisId(1, 0, 51, 4, 0), IntField, units
 DEFINE_FIELD(fuse_treshold_l3, uint16_t, ObisId(1, 0, 71, 4, 0), IntField, units::A);
 
 /* Instantaneous current L1 in A resolution */
-DEFINE_FIELD(current_l1, uint16_t, ObisId(1, 0, 31, 7, 0), IntField, units::A);
+DEFINE_FIELD(current_l1, FixedValue, ObisId(1, 0, 31, 7, 0), FixedField, units::A,units::mA);
 /* Instantaneous current L2 in A resolution */
-DEFINE_FIELD(current_l2, uint16_t, ObisId(1, 0, 51, 7, 0), IntField, units::A);
+DEFINE_FIELD(current_l2, FixedValue, ObisId(1, 0, 51, 7, 0), FixedField, units::A,units::mA);
 /* Instantaneous current L3 in A resolution */
-DEFINE_FIELD(current_l3, uint16_t, ObisId(1, 0, 71, 7, 0), IntField, units::A);
+DEFINE_FIELD(current_l3, FixedValue, ObisId(1, 0, 71, 7, 0), FixedField, units::A,units::mA);
 
 /* Instantaneous active power L1 (+P) in W resolution */
 DEFINE_FIELD(power_delivered_l1, FixedValue, ObisId(1, 0, 21, 7, 0), FixedField, units::kW, units::W);

--- a/src/dsmr-be/fields-be.h
+++ b/src/dsmr-be/fields-be.h
@@ -280,11 +280,11 @@ DEFINE_FIELD(fuse_treshold_l2, uint16_t, ObisId(1, 0, 51, 4, 0), IntField, units
 DEFINE_FIELD(fuse_treshold_l3, uint16_t, ObisId(1, 0, 71, 4, 0), IntField, units::A);
 
 /* Instantaneous current L1 in A resolution */
-DEFINE_FIELD(current_l1, FixedValue, ObisId(1, 0, 31, 7, 0), FixedField, units::A,units::mA);
+DEFINE_FIELD(current_l1, FixedValue, ObisId(1, 0, 31, 7, 0), FixedField, units::A, units::mA);
 /* Instantaneous current L2 in A resolution */
-DEFINE_FIELD(current_l2, FixedValue, ObisId(1, 0, 51, 7, 0), FixedField, units::A,units::mA);
+DEFINE_FIELD(current_l2, FixedValue, ObisId(1, 0, 51, 7, 0), FixedField, units::A, units::mA);
 /* Instantaneous current L3 in A resolution */
-DEFINE_FIELD(current_l3, FixedValue, ObisId(1, 0, 71, 7, 0), FixedField, units::A,units::mA);
+DEFINE_FIELD(current_l3, FixedValue, ObisId(1, 0, 71, 7, 0), FixedField, units::A, units::mA);
 
 /* Instantaneous active power L1 (+P) in W resolution */
 DEFINE_FIELD(power_delivered_l1, FixedValue, ObisId(1, 0, 21, 7, 0), FixedField, units::kW, units::W);


### PR DESCRIPTION
The current version of the library handles instantanteous current (31,51,71) as IntField whereas the new spec actually formats the fields as Fixedvalue.
I was still running the generic dsmr.h version until suddenly on 5/2/2021 17:00 the setup broke and no telegrams were processed anymore. After some unsuccessful troubleshooting (telegrams were present but no parsing by DSMR-WS 1.0.5) I decided to upgrade to 2.0 and implement the dsmr-be library.
Now the library was showing output in the telnet session, but still errors with instantaneous current ...
The error message was : 'Missing Unit' as it couldn't handle the decimal point at the position where the unit was supposed to be.
This the telegram format for the 3 fields :
1-0:31.7.0(001.67*A)
1-0:51.7.0(001.28*A)
1-0:71.7.0(000.95*A)

Not sure what happened yesterday (rollout of update DSMR by Fluvius?) but the dsmr-be didn't work for me.
I have a Siconia T211 tri-phase meter (3x400-32A), happily monitoring it into my Loxone/InfluxDB/grafana monitoring suite using the DSMR-API from Willem.

Hope this patch works for other users too. Maybe check if this still works on meters that publish current in 'Int'-format.

M.
